### PR TITLE
README.md: remove outdated information, add data dir and port information

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Client and Game development for Source of Mana, a The Mana World story.
 
+Both server and client save their data to `$XDG_DATA_HOME/SourceOfMana` on Linux or `\AppData\Roaming\SourceOfMana` on Windows or `~/Library/Application Support/SourceOfMana` on macOS.
+
 ## Tools
 
 Game editor:
@@ -26,7 +28,9 @@ With prebuilt binary:
 "./Source of Mana" --server --headless
 ```
 
-Note that SOM writes the list of online players, `online.json`, next to the SOM or godot executable.
+The server expects a fullchain certificate as `server.crt` and its private key as `server.key` in the root of its data directory, which is mentioned above.
+
+The server accepts connections on port 6118 (tcp) and port 6119 (udp).
 
 ## License
 


### PR DESCRIPTION
I just tested what ports it uses by default.

Data dir information comes from https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-method-get-user-data-dir.